### PR TITLE
Add ability to pass compiler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ $ traceur-runner test/*.js
 Or you can use it programmatically: if you do
 
 ```js
-require("traceur-runner");
+require("traceur-runner")();
+```
+
+Pass some options to the compiler
+
+```js
+require("traceur-runner")({ asyncFunctions: true });
 ```
 
 in your source file, any further `require`s will be transpiled as appropriate.

--- a/bin/traceur-runner.js
+++ b/bin/traceur-runner.js
@@ -3,7 +3,7 @@
 var path = require("path");
 var glob = require("glob");
 
-require("../lib/traceur-runner.js");
+require("../lib/traceur-runner.js")();
 
 process.argv.slice(2).forEach(function (filename) {
     glob.sync(path.resolve(process.cwd(), filename)).forEach(require);

--- a/lib/traceur-runner.js
+++ b/lib/traceur-runner.js
@@ -5,16 +5,18 @@ var fs = require("fs");
 
 require("traceur-source-maps").install(traceur);
 
-traceur.require.makeDefault(function (filename) {
-    var segments = filename.split(/(?:\/|\\)/);
-    var nodeModulesIndex = segments.lastIndexOf("node_modules");
-    if (nodeModulesIndex === -1) {
-        return true;
-    }
+module.exports = function (options) {
+    traceur.require.makeDefault(function (filename) {
+        var segments = filename.split(/(?:\/|\\)/);
+        var nodeModulesIndex = segments.lastIndexOf("node_modules");
+        if (nodeModulesIndex === -1) {
+            return true;
+        }
 
-    var packagePath = segments.slice(0, nodeModulesIndex + 2).join(path.sep) + path.sep + "package.json";
-    var packageContents = fs.readFileSync(packagePath, { encoding: "utf-8" });
-    var packageJSON = JSON.parse(packageContents);
+        var packagePath = segments.slice(0, nodeModulesIndex + 2).join(path.sep) + path.sep + "package.json";
+        var packageContents = fs.readFileSync(packagePath, { encoding: "utf-8" });
+        var packageJSON = JSON.parse(packageContents);
 
-    return !!packageJSON["traceur-runner"];
-});
+        return !!packageJSON["traceur-runner"];
+    }, options || {});
+};


### PR DESCRIPTION
Greetings,

it would be nice to be able to pass options to the compiler. Most notably experimental stuff.
Would something like this be acceptable ?
The drawback is it involves a function call `require('traceur-runner')();` 
